### PR TITLE
Procfile: inicializa servidor depois de rodar migrations

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: alembic upgrade head & uvicorn server:app --host=0.0.0.0 --port=${PORT:-5000}
+web: alembic upgrade head && uvicorn server:app --host=0.0.0.0 --port=${PORT:-5000}


### PR DESCRIPTION
No shell, um & significa rodar em background. Então, ao fazer cmd1 &
cmd2, o bash inicializa cmd1 em background e imediatamente depois roda
cmd2.

Então o comando `alembic ugprade head & uvicorn ...` roda as migrations
em paralelo com o processo do servidor de aplicação, a inicialize o
servidor ainda que as migrações falhem. Imagino que isso não seja o
desejado?

Relacionado à issue #4.